### PR TITLE
logo arriba y boton rojo más pequeño

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -1,5 +1,4 @@
 .logo{
   width: 180px;
   height: 180px;  
-  -webkit-box-reflect: above 0px linear-gradient(to bottom, rgba(0,0,0,0.0), rgba(0,0,0,0.4));
 }

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,4 +1,4 @@
-<div class="jumbotron jumbotron-fluid banner mb-5 d-flex align-items-center" style="background-image: linear-gradient(rgba(0,0,0,0.1),rgba(0,0,0,0.1)), url(https://www.crystalnails.com/global/images/compact_base_gels.jpg);">
+<div class="jumbotron jumbotron-fluid banner mb-5 d-flex" style="background-image: linear-gradient(rgba(0,0,0,0.1),rgba(0,0,0,0.1)), url(https://www.crystalnails.com/global/images/compact_base_gels.jpg);">
  
   <div class="container">
     <div class="d-flex justify-content-center">
@@ -9,7 +9,7 @@
         <h5 class="display-4 text-center"></h5>
         </div>
         <div class="d-flex justify-content-center">
-        <%= link_to "Todas las Marcas en 1 Click", products_path, class: "btn btn-info" %>
+        <%= link_to "Todo en 1 Click", products_path, class: "btn btn-info" %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Posición del logo más arriba y el botón rojo quedó más pequeño para no "ensuciar" las imágenes. Ambos quedaron en un fondo neutro. 